### PR TITLE
Retether-3.4.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@
 
 - `keras_shape` objects (as returned by `keras3::shape()`) gain `==` and `!=` methods.
 
+- Added compatibility with Keras v3.4.1 (no R user facing changes).
+
 User facing changes with upstream Keras v3.4.0:
 
 - New function:

--- a/R/install.R
+++ b/R/install.R
@@ -95,6 +95,10 @@ install_keras <- function(
     packages = NULL
   )
   extra_packages <- unique(extra_packages)
+
+  if(!any(grepl("^numpy[=><!]?", extra_packages)))
+    extra_packages <- c(extra_packages, "numpy<2")
+
   if (length(extra_packages))
     reticulate::py_install(extra_packages, envname = envname)
 


### PR DESCRIPTION
Updates for Keras 3.4.1. This will be released to CRAN once confirmed to work with the upcoming TensorFlow 2.17.0 release.