### PR TITLE
fix issue [#1509](https://github.com/rstudio/keras3/issues/1509)

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -66,7 +66,11 @@ install_keras <- function(
       # tensorflow <- c("tensorflow", "tensorflow-metal")
     } else if (is_linux()) {
       jax <- c("jax[cuda12]")
-      tensorflow <- "tensorflow-cpu"
+      # if there is only one backend, it must be "tensorflow"
+      # for the Linux user requesting only tensorflow and GPU,
+      # we should install the "tensorflow[and-gpu]"
+      # otherwise (requesting other backends), only cpu version is installed
+      tensorflow <- if (length(backend) == 1) "tensorflow[and-gpu]" else "tensorflow-cpu"
     }
   } else { # no GPU
     jax <- "jax[cpu]"


### PR DESCRIPTION
This is my fix of issue #1509. As also explained in the bug report, the function logic regarding "Linux installing GPU-enabled tensorflow-backend" fails to install the GPU version, but only with CPU.

I have added a "if-else" block to check if "tensorflow" was the only backend requested GPU on Linux. If so, we install tensorflow with GPU support. Otherwise, i.e. there are multiple backends requested (as tensorflow is always enabled), we need to install only the CPU version of tensorflow.

Thanks!