### PR TITLE
Set `UV_CONSTRAINT` and `UV_OVERRIDE` for better compat with `keras-hub`  and `tensorflow-text`

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -224,11 +224,11 @@ use_backend <- function(backend, gpu = NA) {
         gpu <- has_gpu()
 
       if (gpu) {
-        uv_unset_tf_cpu_override()
+        uv_unset_override_tf_cpu()
         py_require(action = "remove", c("tensorflow", "tensorflow-cpu"))
         py_require("tensorflow[and-cuda]")
       } else {
-        py_require_tf_cpu()
+        uv_set_override_tf_cpu()
       }
     },
 
@@ -236,7 +236,7 @@ use_backend <- function(backend, gpu = NA) {
       py_require(action = "remove",
                  c("tensorflow", "tensorflow[and-cuda]",
                    "jax[cuda12]", "jax[cpu]"))
-      py_require_tf_cpu()
+      uv_set_override_tf_cpu()
 
       if (is.na(gpu))
         gpu <- has_gpu()
@@ -251,7 +251,7 @@ use_backend <- function(backend, gpu = NA) {
 
     Linux_torch = {
       py_require(c("tensorflow", "tensorflow[and-cuda]"), action = "remove")
-      py_require_tf_cpu()
+      uv_set_override_tf_cpu()
 
       if (is.na(gpu))
         gpu <- has_gpu()
@@ -268,7 +268,7 @@ use_backend <- function(backend, gpu = NA) {
     },
 
     Linux_numpy = {
-      py_require_tf_cpu()
+      uv_set_override_tf_cpu()
       py_require(c("tensorflow", "tensorflow[and-cuda]"), action = "remove")
       py_require(c("tensorflow-cpu", "numpy", "jax[cpu]"))
     },
@@ -337,7 +337,7 @@ set_envvar <- function(
   invisible(old)
 }
 
-py_require_tf_cpu <- function() {
+uv_set_override_tf_cpu <- function() {
   py_require(action = "remove", c(
     "tensorflow", "tensorflow[and-cuda]", "tensorflow-cpu",
     "tensorflow-metal", "tensorflow-macos"
@@ -347,7 +347,7 @@ py_require_tf_cpu <- function() {
              action = "append", sep = " ", unique = TRUE)
 }
 
-uv_unset_tf_cpu_override <- function() {
+uv_unset_override_tf_cpu <- function() {
   override <- Sys.getenv("UV_OVERRIDE", NA)
   if (is.na(override)) return()
   cpu_override <- pkg_file("tf-cpu-override.txt")

--- a/inst/keras-constraints.txt
+++ b/inst/keras-constraints.txt
@@ -5,5 +5,5 @@
 keras-hub>0.19.0
 
 
-# tensorflow-text 2.19 fails to load with tensorflow-cpu>=2.19
+# tensorflow-text 2.19.* fails to load with tensorflow-cpu>=2.19.0
 tensorflow-cpu==2.18.*

--- a/inst/keras-constraints.txt
+++ b/inst/keras-constraints.txt
@@ -1,0 +1,9 @@
+
+# unconstrained keras-hub in a larger requirements list might resolve to v0.19.0,
+# which is over a year old and generally what people want, and arguably a bug with `uv`.
+# This is a workaround to nudge uv to resolve the latest keras-hub.
+keras-hub>0.19.0
+
+
+# tensorflow-text 2.19 fails to load with tensorflow-cpu>=2.19
+tensorflow-cpu==2.18.*

--- a/inst/tf-cpu-override.txt
+++ b/inst/tf-cpu-override.txt
@@ -1,0 +1,1 @@
+tensorflow; sys_platform == "never"

--- a/tools/install.R
+++ b/tools/install.R
@@ -1,0 +1,3 @@
+#!/usr/bin/Rscript
+
+remotes::install_local(force = TRUE)


### PR DESCRIPTION
There is a minor patchwork of incompatibilities to avoid between keras-hub, tensorflow-text, and tensorflow-cpu. 

This PR has us set `UV_CONSTRAINT` and `UV_OVERRIDE` to ensure that the following simple usage "just works":

```r
library(keras3)
use_backend(ANY, gpu = ANY)

py_require(c("keras-hub", "tensorflow-text"))
keras_hub <- import("keras_hub")
...
```